### PR TITLE
Updated for Ubuntu 22.04

### DIFF
--- a/VLC/build.md
+++ b/VLC/build.md
@@ -1,17 +1,19 @@
 # Configure and build VLC from scratch
 
 ## Ubuntu
-- Install Ubuntu 20.04 LTS
+- Install Ubuntu 22.04 LTS
 
 ## Qt
-- Install Qt 5.11.3 -> Desktop Gcc 64-bit module:
-    - https://download.qt.io/new_archive/qt/5.11/5.11.3
+- `sudo apt-get install libxcb-xinerama0`  # NOTE: This is required for running Qt installation file
+- Install Qt 5.11.3 and Qt 5.15.2 -> Desktop Gcc 64-bit module:
+    - https://download.qt.io/official_releases/online_installers/
+    - Upon installation, select to show 'Archives' in order to install both 5.11.3 and 5.15.2
 
 ## Install
 - `sudo apt install git build-essential pkg-config libtool automake autopoint gettext`
-- `sudo apt install python`         # NOTE: This is required for building 'tools'
 - `sudo apt install cmake`          # NOTE: This is required for building 'contrib'
-- `sudo apt install libxcb-xkb-dev` # NOTE: This is required for building 'vlc'
+- `sudo apt install libxcb-xkb-dev qtdeclarative5-dev qtquickcontrols2-5-dev` # NOTE: This is required for building 'vlc'
+- `sudo apt-get install qml-module-qtgraphicaleffects qml-module-qtqml-models2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-templates2` # NOTE: This is required for running 'vlc'
 - Enable sources on Ubuntu (https://askubuntu.com/questions/496549/error-you-must-put-some-source-uris-in-your-sources-list)
 - `sudo apt-get build-dep vlc`
 
@@ -20,11 +22,10 @@
     - fork https://code.videolan.org/videolan/vlc
 - Generate rsa: `ssh-keygen -t rsa -b 2048 -C "{YOUR_EMAIL}"`
 - Upload {YOUR_HOME}/.ssh/id_rsa.pub to code.videolan.org
-- `sudo apt install git`
 - git clone https://code.videolan.org/{$YOUR_FORK}/vlc
 
 ## VLC tools
-- `cd vlc/extra/tools`
+- `cd vlc/extras/tools`
 - `./bootstrap`
 - `make -j4`
 
@@ -32,7 +33,7 @@
 - `cd ../../contrib`
 - `mkdir contrib-nativ`
 - `cd contrib-nativ`
-- `../bootstrap`
+- `../bootstrap --disable-gcrypt --disable-bluray`
 - `make -j4`
 
 ## VLC
@@ -40,5 +41,5 @@
 - `./bootstrap`
 - `mkdir build-qt11`
 - `cd build-qt11`
-- `../configure '--disable-optimizations' '--enable-debug' '--disable-nls' '--without-kde-solid' '--enable-qt-qml-cache' '--enable-qt-qml-debug' '--disable-skins2' '--disable-upnp' '--disable-chromecast' '--disable-srt' '--disable-aom' '--disable-bluray' 'CFLAGS=-ggdb -O0 -fno-omit-frame-pointer' 'PKG_CONFIG_PATH={YOUR_HOME}/Qt/Qt5.11.3/5.11.3/gcc_64/lib/pkgconfig/:{YOUR_HOME}/dev/videolan/vlc/contrib/x86_64-linux-gnu/lib/pkgconfig'`
+- `../configure '--disable-optimizations' '--enable-debug' '--disable-nls' '--without-kde-solid' '--enable-qt-qml-cache' '--enable-qt-qml-debug' '--disable-skins2' '--disable-upnp' '--disable-chromecast' '--disable-srt' '--disable-aom' '--disable-bluray' 'CFLAGS=-ggdb -O0 -fno-omit-frame-pointer' 'PKG_CONFIG_PATH=$HOME/Qt/5.11.3/gcc_64/lib/pkgconfig/:$HOME/vlc/contrib/x86_64-linux-gnu/lib/pkgconfig'`
 - `make -j4`


### PR DESCRIPTION
Changes:
- Installation of both Qt 5.11.3 and Qt 5.15.2, that vlc needs to be tested
- Removed installation of python package, since python package doesn't exist, but python3 is preinstalled
- Added two Qt packages required to build vlc
- Added some qml packages required to run vlc
- Typo on tools path
- Added --disable-gcrypt --disable-bluray to bootstrap contrib (As suggested by Pierre)
- Fixed PKG_CONFIG_PATH when configuring the vlc build